### PR TITLE
Standardize naming in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# GTFSRT-Best-Practices
+# GTFS_Realtime_Best-Practices
 
 Best Practices for Structuring GTFS Realtime Data
 
-# Editing GTFSRT Best Practices
+# Editing GTFS Realtime Best Practices
 
 The Best Practices data are written in Markdown and is organized by Message and by use case.
 


### PR DESCRIPTION
Follow MobilityData's spec naming rules for clarity. (https://gtfs.mobilitydata.org/)