### PR TITLE
Add best practice to match route_id, trip_id, and direction_id

### DIFF
--- a/en/TripDescriptor.md
+++ b/en/TripDescriptor.md
@@ -4,6 +4,8 @@ If separate `VehiclePosition` and `TripUpdate` feeds are provided, [TripDescript
 
 For example, a `VehiclePosition` entity has `vehicle_id:A` and `trip_id:4`, then the corresponding `TripUpdate` entity should also have `vehicle_id:A` and `trip_id:4`.
 
+When `schedule_relationship` is `SCHEDULED`, `route_id`, `trip_id`, and `direction_id` SHOULD match the referenced `route_id`, `trip_id`, and `direction_id` in the GTFS Schedule (static) dataset (feed). 
+
 | Field Name | Recommendation |
 | --- | --- |
 | trip_id | |


### PR DESCRIPTION
The [GTFS Realtime spec right now](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/trip-updates.md#trip-descriptor)  isn't specific on when these need to be matched; this clarifies it.

**Best Practice Proposal:**
Recommend use of consistent `route_id`, `trip_id`, and `direction_id` between GTFS Realtime and corresponding GTFS Schedule when `schedule_relationship` is `SCHEDULED` 


