### PR TITLE
Update README.md with transifer to google/transit note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GTFS Realtime Best Practices
 
 Best Practices for Structuring [GTFS Realtime](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md) Data.
+⚠️ NOTE: The best practices are in the process of being merged into the spec. If you'd like to suggest a new best practice, please go to https://github.com/google/transit/ to open an issue or create a PR. ⚠️
 
 ## Current Version
 **The current release is v1.0**


### PR DESCRIPTION
Similar to the GTFS Schedule Best Practices, we'd like the Realtime Best Practices to be transferred to the GTFS Realtime reference at some point. 

This PR updates the README.md similarly to the [GTFS Schedule Best Practices](https://github.com/MobilityData/GTFS_Schedule_Best-Practices).