### PR TITLE
Update documentation to make the "GTFS Best Practices" term more clear

### DIFF
--- a/en/about.md
+++ b/en/about.md
@@ -9,7 +9,9 @@ The objectives of maintaining GTFS Realtime Best Practices are to:
 
 ### How to propose or amend published GTFS Realtime Best Practices
 
-The Best Practices are in the process of being merged into the spec. If you'd like to suggest a new best practice, please go to the [GTFS Reference GitHub repository](https://github.com/google/transit/) to open an issue or create a PR, or contact [specifications@mobilitydata.org](mailto:specifications@mobilitydata.org).
+The Best Practices are in the process of being merged into the spec and some GTFS Best Practices have been merged into the official GTFS Realtime reference and have been removed from this document.
+
+If you'd like to suggest a new best practice, please go to the [GTFS Reference GitHub repository](https://github.com/google/transit/) to open an issue or create a PR, or contact [specifications@mobilitydata.org](mailto:specifications@mobilitydata.org).
 
 ### Linking to This Document
 

--- a/en/about.md
+++ b/en/about.md
@@ -9,7 +9,7 @@ The objectives of maintaining GTFS Realtime Best Practices are to:
 
 ### How to propose or amend published GTFS Realtime Best Practices
 
-The Best Practices are in the process of being merged into the spec and some GTFS Best Practices have been merged into the official GTFS Realtime reference and have been removed from this document.
+The Best Practices are in the process of being merged into the official GTFS Realtime reference, and some GTFS Best Practices will be removed from this document as this is happening.
 
 If you'd like to suggest a new best practice, please go to the [GTFS Reference GitHub repository](https://github.com/google/transit/) to open an issue or create a PR, or contact [specifications@mobilitydata.org](mailto:specifications@mobilitydata.org).
 

--- a/en/introduction.md
+++ b/en/introduction.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-These are recommended practices for describing real-time public transportation information in the [GTFS Realtime](https://gtfs.org/reference/realtime/v2/) data format. These complement the explicit recommendations outlined in the GTFS Schedule Reference using the terms “recommend” or “should”. Although not mandatory, following these best practices can significantly improve the quality of the data and the overall experience for riders.
+These are recommended practices for describing real-time public transportation information in the [GTFS Realtime Reference](https://gtfs.org/realtime/reference/) format. These complement the explicit recommendations outlined in the GTFS Realtime Reference using the terms “recommend” or “should”. Although not mandatory, following these best practices can significantly improve the quality of the data and the overall experience for riders.
 
 These practices have been synthesized from the experience of the [GTFS Best Practices working group](https://gtfs.org/schedule/best-practices/#gtfs-best-practices-working-group) members and [application-specific GTFS practice recommendations](http://www.transitwiki.org/TransitWiki/index.php/Best_practices_for_creating_GTFS). 
 

--- a/en/introduction.md
+++ b/en/introduction.md
@@ -1,8 +1,12 @@
-# GTFS Realtime Data Best Practices
+# GTFS Realtime Best Practices
 
 ## Introduction
 
-These are recommended practices for describing realtime public transportation information in the [GTFS Realtime](https://gtfs.org/reference/realtime/v2/) data format.
+These are recommended practices for describing real-time public transportation information in the [GTFS Realtime](https://gtfs.org/reference/realtime/v2/) data format. These complement the explicit recommendations outlined in the GTFS Schedule Reference using the terms “recommend” or “should”. Although not mandatory, following these best practices can significantly improve the quality of the data and the overall experience for riders.
+
+These practices have been synthesized from the experience of the [GTFS Best Practices working group](https://gtfs.org/schedule/best-practices/#gtfs-best-practices-working-group) members and [application-specific GTFS practice recommendations](http://www.transitwiki.org/TransitWiki/index.php/Best_practices_for_creating_GTFS). 
+
+For further background, see the [Frequently Asked Questions](https://gtfs.org/schedule/best-practices/#frequently-asked-questions-faq).
 
 ### Document Structure
 


### PR DESCRIPTION
GTFS Realtime Best Practices are in the process of being merged into the official GTFS Realtime Reference as recommendations.

What we now call GTFS Realtime Best Practices is:

> recommendations are either explicitly suggested by the GTFS Realtime Reference, using the term “recommend” or “should,” or mentioned in the official GTFS Realtime Best Practices.

This PR adds clarification statements to make this more clear, supporting efforts to comply with the GTFS Realtime Best Practices.